### PR TITLE
Fix self triggered chat sounds for ironman

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.18'
+def runeLiteVersion = '1.7.27'
 
 dependencies {
 	implementation files('libs/jaco-mp3-player-0.9.5.jar')

--- a/src/main/java/com/chatsounds/ChatSoundsPlugin.java
+++ b/src/main/java/com/chatsounds/ChatSoundsPlugin.java
@@ -59,9 +59,10 @@ public class ChatSoundsPlugin extends Plugin
 	public void onChatMessage(ChatMessage event)
 	{
 		Player player = client.getLocalPlayer();
+		String eventName = removePrefixedImageFromName(event.getName());
 		if (player == null ||
 			client.getGameState() != GameState.LOGGED_IN ||
-			event.getName().equals(player.getName()))
+			eventName.equals(player.getName()))
 		{
 			return;
 		}
@@ -89,6 +90,17 @@ public class ChatSoundsPlugin extends Plugin
 				}
 				break;
 		}
+	}
+
+	// Special accounts types have an icon prepended onto the chat event's name in certain chat channels.
+	// i.e. "<img=99>Username"
+	private String removePrefixedImageFromName(String text) {
+		boolean startsWithImgMarkup = text.startsWith("<img") && text.contains(">");
+		boolean hasTextAfterMarkup = text.indexOf(">") != text.length() - 1;
+		if (startsWithImgMarkup && hasTextAfterMarkup) {
+			text = text.substring(text.indexOf(">") + 1);
+		}
+		return text;
 	}
 
 	private void initSoundFiles()


### PR DESCRIPTION
On accounts with chat badges it seems that the ChatMessage event's name contains the markup for the chat badge in some channels, such that the name is of the format: `"<img=99>Notloc"`

This causes ironman mode accounts (and I assumed J/P Mods as well) to trigger the chat sound with their own messages in affected channels. (I first noticed it in channel chat)
I simply added a function to remove the chat badge markup if present.