### PR TITLE
Fix broadcast sound alerts and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Sets the global volume of the sound effects (0-100%).
 * **Default:** The default sound effect that comes with the plugin. Big thanks to [Creator Assets!](https://creatorassets.com/a/notification-sound-effects)
 
 
-* **Custom:** Let's you play a custom sound effect for the specified channel. Go to your `/.runelite/chat-sounds/` directory and replace the corresponding mp3 file(s) to use custom sounds. For example, if you want a custom sound effect for Clan Chat messages, you would replace `cs_clan.mp3` with a different mp3 file **of the same name**.
-![image](https://user-images.githubusercontent.com/18340303/125236058-5babb300-e2b1-11eb-8fa6-dda85ba89678.png)
+* **Custom:** Let's you play a custom sound effect for the specified channel. Go to your `~/.runelite/chat-sounds/` directory and replace the corresponding **.wav** file(s) to use custom sounds. For example, if you want a custom sound effect for Clan Chat messages, you would replace `cs_clan.wav` with a different **.wav** file **of the same name**.
+
 
 
 * **Off:** Disables sound effects for the specified channel.

--- a/src/main/java/com/chatsounds/BroadcastType.java
+++ b/src/main/java/com/chatsounds/BroadcastType.java
@@ -5,8 +5,8 @@ import java.util.regex.Pattern;
 public enum BroadcastType
 {
     // Social
-    PLAYER_JOIN_LEAVE(MatchMode.ANY, " has joined.",
-            " has left."),
+    PLAYER_JOIN_LEAVE(MatchMode.ANY, "has joined",
+            "has left"),
     CLAN_INVITATION(MatchMode.ANY,
             "has been invited into the"
     ),
@@ -61,11 +61,11 @@ public enum BroadcastType
             "has completed the (elite|hard|medium|easy)( [a-z ]+)? diary$"
     ),
     COMBAT_ACHIEVEMENT_TIER(MatchMode.REGEX,
-            "has unlocked the (easy|medium|hard|elite|master) tier of rewards from combat achievements"
+            "has unlocked the (easy|medium|hard|elite|master|grandmaster) tier of rewards from combat achievements"
     ),
 
     COMBAT_ACHIEVEMENT_TASK(MatchMode.REGEX,
-            "has completed a[n]? (easy|medium|hard|elite|master) combat task: .+"
+            "has completed a[n]? (easy|medium|hard|elite|master|grandmaster) combat task.+"
     ),
     PERSONAL_BEST(MatchMode.ANY,
             "achieved a new"

--- a/src/main/java/com/chatsounds/BroadcastType.java
+++ b/src/main/java/com/chatsounds/BroadcastType.java
@@ -1,5 +1,7 @@
 package com.chatsounds;
 
+import java.util.regex.Pattern;
+
 public enum BroadcastType
 {
     // Social
@@ -13,15 +15,16 @@ public enum BroadcastType
     ),
 
     // Loot and collection log
-    REGULAR_DROP(MatchMode.ANY,
-            "received a drop"
-    ),
     RARE_DROP(MatchMode.ANY,
             "received a rare drop"
+    ),
+    REGULAR_DROP(MatchMode.ANY,
+        "received a drop"
     ),
     RAID_LOOT(MatchMode.ANY,
             "received special loot from a raid"
     ),
+
     PET(MatchMode.ANY,
             "has a funny feeling",
             "acquired something special",
@@ -32,10 +35,6 @@ public enum BroadcastType
     ),
 
     // Levels and XP
-    LEVEL_UP(MatchMode.ALL,
-            "has reached",
-            "level"
-    ),
     COMBAT_LEVEL_UP(MatchMode.ANY,
             "has reached combat level",
             "highest possible combat level"
@@ -49,28 +48,35 @@ public enum BroadcastType
             "has reached",
             "xp in"
     ),
+    LEVEL_UP(MatchMode.ALL,
+            "has reached",
+            "level"
+    ),
 
     // Achievements
     QUEST_COMPLETE(MatchMode.ANY,
             "has completed a quest"
     ),
-    ACHIEVEMENT_DIARY(MatchMode.ANY,
-            "achievement diary"
+    ACHIEVEMENT_DIARY(MatchMode.REGEX,
+            "has completed the (elite|hard|medium|easy)( [a-z ]+)? diary$"
     ),
-    COMBAT_ACHIEVEMENT(MatchMode.ANY,
-            "combat achievement",
-            "combat task"
+    COMBAT_ACHIEVEMENT_TIER(MatchMode.REGEX,
+            "has unlocked the (easy|medium|hard|elite|master) tier of rewards from combat achievements"
+    ),
+
+    COMBAT_ACHIEVEMENT_TASK(MatchMode.REGEX,
+            "has completed a[n]? (easy|medium|hard|elite|master) combat task: .+"
     ),
     PERSONAL_BEST(MatchMode.ANY,
             "achieved a new"
     ),
 
     // PvP & deaths
-    PLAYER_KILL(MatchMode.ANY,
-            "has defeated"
-    ),
     PLAYER_DEATH(MatchMode.ANY,
             "has been defeated by"
+    ),
+    PLAYER_KILL(MatchMode.ANY,
+            "has defeated"
     ),
     HARDCORE_DEATH(MatchMode.ANY,
             "lost their hardcore"
@@ -81,11 +87,20 @@ public enum BroadcastType
 
     private final MatchMode matchMode;
     private final String[] phrases;
+    private final Pattern pattern;
 
     BroadcastType(MatchMode matchMode, String... phrases)
     {
         this.matchMode = matchMode;
         this.phrases = phrases;
+        if (matchMode == MatchMode.REGEX && phrases.length > 0)
+        {
+            this.pattern = Pattern.compile(phrases[0], Pattern.CASE_INSENSITIVE);
+        }
+        else
+        {
+            this.pattern = null;
+        }
     }
 
     public boolean matches(String message)
@@ -101,18 +116,22 @@ public enum BroadcastType
         {
             for (String phrase : phrases)
             {
-                if (!m.contains(phrase))
+                if (!m.contains(phrase.toLowerCase()))
                 {
                     return false;
                 }
             }
             return true;
         }
+        else if (matchMode == MatchMode.REGEX)
+        {
+            return pattern != null && pattern.matcher(message).find();
+        }
         else // MatchMode.ANY
         {
             for (String phrase : phrases)
             {
-                if (m.contains(phrase))
+                if (m.contains(phrase.toLowerCase()))
                 {
                     return true;
                 }
@@ -133,5 +152,3 @@ public enum BroadcastType
         return OTHER;
     }
 }
-
-

--- a/src/main/java/com/chatsounds/BroadcastType.java
+++ b/src/main/java/com/chatsounds/BroadcastType.java
@@ -77,9 +77,6 @@ public enum BroadcastType
     ),
 
     // Other
-    LEAGUES_BROADCAST(MatchMode.ANY,
-            "<img=22>"
-    ),
     OTHER(MatchMode.ANY);
 
     private final MatchMode matchMode;

--- a/src/main/java/com/chatsounds/BroadcastType.java
+++ b/src/main/java/com/chatsounds/BroadcastType.java
@@ -24,6 +24,9 @@ public enum BroadcastType
     RAID_LOOT(MatchMode.ANY,
             "received special loot from a raid"
     ),
+    CLUE_LOOT(MatchMode.ANY,
+            "received a clue item"
+    ),
 
     PET(MatchMode.ANY,
             "has a funny feeling",

--- a/src/main/java/com/chatsounds/BroadcastType.java
+++ b/src/main/java/com/chatsounds/BroadcastType.java
@@ -1,0 +1,140 @@
+package com.chatsounds;
+
+public enum BroadcastType
+{
+    // Social
+    PLAYER_JOIN_LEAVE(MatchMode.ANY, " has joined.",
+            " has left."),
+    CLAN_INVITATION(MatchMode.ANY,
+            "has been invited into the"
+    ),
+    CLAN_EXPULSION(MatchMode.ANY,
+            "has expelled"
+    ),
+
+    // Loot and collection log
+    REGULAR_DROP(MatchMode.ANY,
+            "received a drop"
+    ),
+    RARE_DROP(MatchMode.ANY,
+            "received a rare drop"
+    ),
+    RAID_LOOT(MatchMode.ANY,
+            "received special loot from a raid"
+    ),
+    PET(MatchMode.ANY,
+            "has a funny feeling",
+            "acquired something special",
+            "something weird sneaking into"
+    ),
+    COLLECTION_LOG(MatchMode.ANY,
+            "a new collection log item"
+    ),
+
+    // Levels and XP
+    LEVEL_UP(MatchMode.ALL,
+            "has reached",
+            "level"
+    ),
+    COMBAT_LEVEL_UP(MatchMode.ANY,
+            "has reached combat level",
+            "highest possible combat level"
+    ),
+    TOTAL_LEVEL_MILESTONE(MatchMode.ANY,
+            "has reached a total",
+            "total level of",
+            "has reached the highest possible total level of"
+    ),
+    XP_MILESTONE(MatchMode.ALL,
+            "has reached",
+            "xp in"
+    ),
+
+    // Achievements
+    QUEST_COMPLETE(MatchMode.ANY,
+            "has completed a quest"
+    ),
+    ACHIEVEMENT_DIARY(MatchMode.ANY,
+            "achievement diary"
+    ),
+    COMBAT_ACHIEVEMENT(MatchMode.ANY,
+            "combat achievement",
+            "combat task"
+    ),
+    PERSONAL_BEST(MatchMode.ANY,
+            "achieved a new"
+    ),
+
+    // PvP & deaths
+    PLAYER_KILL(MatchMode.ANY,
+            "has defeated"
+    ),
+    PLAYER_DEATH(MatchMode.ANY,
+            "has been defeated by"
+    ),
+    HARDCORE_DEATH(MatchMode.ANY,
+            "lost their hardcore"
+    ),
+
+    // Other
+    LEAGUES_BROADCAST(MatchMode.ANY,
+            "<img=22>"
+    ),
+    OTHER(MatchMode.ANY);
+
+    private final MatchMode matchMode;
+    private final String[] phrases;
+
+    BroadcastType(MatchMode matchMode, String... phrases)
+    {
+        this.matchMode = matchMode;
+        this.phrases = phrases;
+    }
+
+    public boolean matches(String message)
+    {
+        if (phrases.length == 0)
+        {
+            return false;
+        }
+
+        String m = message.toLowerCase();
+
+        if (matchMode == MatchMode.ALL)
+        {
+            for (String phrase : phrases)
+            {
+                if (!m.contains(phrase))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+        else // MatchMode.ANY
+        {
+            for (String phrase : phrases)
+            {
+                if (m.contains(phrase))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    public static BroadcastType detect(String message)
+    {
+        for (BroadcastType type : values())
+        {
+            if (type != OTHER && type.matches(message))
+            {
+                return type;
+            }
+        }
+        return OTHER;
+    }
+}
+
+

--- a/src/main/java/com/chatsounds/BroadcastType.java
+++ b/src/main/java/com/chatsounds/BroadcastType.java
@@ -58,14 +58,14 @@ public enum BroadcastType
             "has completed a quest"
     ),
     ACHIEVEMENT_DIARY(MatchMode.REGEX,
-            "has completed the (elite|hard|medium|easy)( [a-z ]+)? diary$"
+            "has completed the .* diary"
     ),
     COMBAT_ACHIEVEMENT_TIER(MatchMode.REGEX,
-            "has unlocked the (easy|medium|hard|elite|master|grandmaster) tier of rewards from combat achievements"
+            "has unlocked the .* tier of rewards from combat achievements"
     ),
 
     COMBAT_ACHIEVEMENT_TASK(MatchMode.REGEX,
-            "has completed a[n]? (easy|medium|hard|elite|master|grandmaster) combat task.+"
+            "has completed a[n]? .* combat task"
     ),
     PERSONAL_BEST(MatchMode.ANY,
             "achieved a new"

--- a/src/main/java/com/chatsounds/BroadcastType.java
+++ b/src/main/java/com/chatsounds/BroadcastType.java
@@ -5,8 +5,10 @@ import java.util.regex.Pattern;
 public enum BroadcastType
 {
     // Social
-    PLAYER_JOIN_LEAVE(MatchMode.ANY, "has joined",
-            "has left"),
+    PLAYER_JOIN_LEAVE(MatchMode.ANY,
+			"has joined",
+            "has left"
+	),
     CLAN_INVITATION(MatchMode.ANY,
             "has been invited into the"
     ),
@@ -19,7 +21,7 @@ public enum BroadcastType
             "received a rare drop"
     ),
     REGULAR_DROP(MatchMode.ANY,
-        "received a drop"
+            "received a drop"
     ),
     RAID_LOOT(MatchMode.ANY,
             "received special loot from a raid"

--- a/src/main/java/com/chatsounds/ChatSoundsConfig.java
+++ b/src/main/java/com/chatsounds/ChatSoundsConfig.java
@@ -349,6 +349,18 @@ public interface ChatSoundsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "clanClueLoot",
+			name = "Clue loot broadcasts",
+			description = "Play a sound for users receiving clue loot.",
+			position = 27,
+			section = clanChatList
+	)
+	default boolean clanClueLoot()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 			keyName = "clanPetDrop",
 			name = "Pet drop broadcasts",
 			description = "Play a sound for users receiving a pet drop.",

--- a/src/main/java/com/chatsounds/ChatSoundsConfig.java
+++ b/src/main/java/com/chatsounds/ChatSoundsConfig.java
@@ -681,10 +681,226 @@ public interface ChatSoundsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "gimRegularDrop",
+			name = "Regular drop broadcasts",
+			description = "Play a sound for group members receiving a regular drop.",
+			position = 52,
+			section = groupList
+	)
+	default boolean gimRegularDrop()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "gimRareDrop",
+			name = "Rare drop broadcasts",
+			description = "Play a sound for group members receiving a rare drop.",
+			position = 53,
+			section = groupList
+	)
+	default boolean gimRareDrop()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "gimRaidLoot",
+			name = "Raid loot broadcasts",
+			description = "Play a sound for group members receiving raid loot.",
+			position = 54,
+			section = groupList
+	)
+	default boolean gimRaidLoot()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "gimClueLoot",
+			name = "Clue loot broadcasts",
+			description = "Play a sound for group members receiving clue loot.",
+			position = 55,
+			section = groupList
+	)
+	default boolean gimClueLoot()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "gimPetDrop",
+			name = "Pet drop broadcasts",
+			description = "Play a sound for group members receiving a pet drop.",
+			position = 56,
+			section = groupList
+	)
+	default boolean gimPetDrop()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "gimCollectionLog",
+			name = "Collection log broadcasts",
+			description = "Play a sound for group members receiving a new collection log item.",
+			position = 57,
+			section = groupList
+	)
+	default boolean gimCollectionLog()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "gimLevelUp",
+			name = "Level up broadcasts",
+			description = "Play a sound for group members leveling up.",
+			position = 58,
+			section = groupList
+	)
+	default boolean gimLevelUp()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "gimCombatLevel",
+			name = "Combat level broadcasts",
+			description = "Play a sound for group members gaining a combat level.",
+			position = 59,
+			section = groupList
+	)
+	default boolean gimCombatLevel()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "gimTotalLevelMilestone",
+			name = "Total level broadcasts",
+			description = "Play a sound for group members reaching a new total level milestone.",
+			position = 60,
+			section = groupList
+	)
+	default boolean gimTotalLevelMilestone()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "gimXpMilestone",
+			name = "XP milestone broadcasts",
+			description = "Play a sound for group members reaching an XP milestone.",
+			position = 61,
+			section = groupList
+	)
+	default boolean gimXpMilestone()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "gimQuest",
+			name = "Quest broadcasts",
+			description = "Play a sound for group members completing a quest.",
+			position = 62,
+			section = groupList
+	)
+	default boolean gimQuest()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "gimDiary",
+			name = "Achievement diary broadcasts",
+			description = "Play a sound for group members completing an achievement diary task.",
+			position = 63,
+			section = groupList
+	)
+	default boolean gimDiary()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "gimCombatAchievementTier",
+			name = "Combat achievement tier broadcasts",
+			description = "Play a sound for group members completing a combat achievement tier.",
+			position = 64,
+			section = groupList
+	)
+	default boolean gimCombatAchievementTier()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "gimCombatAchievementTask",
+			name = "Combat achievement task broadcasts",
+			description = "Play a sound for group members completing a combat achievement task.",
+			position = 65,
+			section = groupList
+	)
+	default boolean gimCombatAchievementTask()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "gimPersonalBest",
+			name = "Personal best broadcasts",
+			description = "Play a sound for group members achieving a new personal best.",
+			position = 66,
+			section = groupList
+	)
+	default boolean gimPersonalBest()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "gimPvpKill",
+			name = "PvP kill broadcasts",
+			description = "Play a sound for group members killing another player.",
+			position = 67,
+			section = groupList
+	)
+	default boolean gimPvpKill()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "gimPvpDeath",
+			name = "PvP death broadcasts",
+			description = "Play a sound for group members dying to another player.",
+			position = 68,
+			section = groupList
+	)
+	default boolean gimPvpDeath()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "gimLeagues",
+			name = "Leagues broadcasts",
+			description = "Include leagues broadcasts.",
+			position = 69,
+			section = groupList
+	)
+	default boolean gimLeagues()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 			keyName = "groupIronIgnorePlayers",
 			name = "Ignore player names",
 			description = "A comma-separated list of player names to never play a sound for.",
-			position = 52,
+			position = 70,
 			section = groupList
 	)
 	default String groupIronIgnorePlayersList()
@@ -698,7 +914,7 @@ public interface ChatSoundsConfig extends Config
 	@ConfigSection(
 			name = "Trade Requests",
 			description = "Settings for trade requests.",
-			position = 53
+			position = 71
 	)
 	String tradeList = "tradeList";
 
@@ -706,7 +922,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "tradeRequest",
 			name = "Trade Request",
 			description = "The sound effect to use when receiving a trade request.",
-			position = 54,
+			position = 72,
 			section = tradeList
 	)
 	default ChatSoundsMode tradeRequest()
@@ -724,7 +940,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "tradeVolume",
 			name = "Trade Volume",
 			description = "Sets the volume of the chat message sound effect.",
-			position = 55,
+			position = 73,
 			section = tradeList
 	)
 	default int tradeVolume()
@@ -736,7 +952,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "tradeIgnorePlayers",
 			name = "Ignore player names",
 			description = "A comma-separated list of player names to never play a sound for.",
-			position = 56,
+			position = 74,
 			section = tradeList
 	)
 	default String tradeIgnorePlayersList()
@@ -750,7 +966,7 @@ public interface ChatSoundsConfig extends Config
 	@ConfigSection(
 			name = "Duel Requests",
 			description = "Settings for duel requests.",
-			position = 57
+			position = 75
 	)
 	String duelList = "duelList";
 
@@ -758,7 +974,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "duelRequest",
 			name = "Duel Request",
 			description = "The sound effect to use when receiving a duel request.",
-			position = 58,
+			position = 76,
 			section = duelList
 	)
 	default ChatSoundsMode duelRequest()
@@ -776,7 +992,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "duelVolume",
 			name = "Duel Volume",
 			description = "Sets the volume of the chat message sound effect.",
-			position = 59,
+			position = 77,
 			section = duelList
 	)
 	default int duelVolume()
@@ -788,7 +1004,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "duelIgnorePlayers",
 			name = "Ignore player names",
 			description = "A comma-separated list of player names to never play a sound for.",
-			position = 60,
+			position = 78,
 			section = duelList
 	)
 	default String duelIgnorePlayersList()

--- a/src/main/java/com/chatsounds/ChatSoundsConfig.java
+++ b/src/main/java/com/chatsounds/ChatSoundsConfig.java
@@ -201,15 +201,15 @@ public interface ChatSoundsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "chatChannelIgnoreJoinLeave",
-			name = "Ignore joined/left messages",
-			description = "Do not play a sound for users joining or leaving chats.",
+			keyName = "chatChannelJoinLeave",
+			name = "Join/leave broadcasts",
+			description = "Play a sound for users joining or leaving the chat-channel.",
 			position = 15,
 			section = chatChannelList
 	)
-	default boolean chatChannelIgnoreJoinLeave()
+	default boolean chatChannelJoinLeave()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(
@@ -277,13 +277,241 @@ public interface ChatSoundsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "clanIgnoreJoinLeave",
-			name = "Ignore joined/left messages",
-			description = "Do not play a sound for users joining or leaving chats.",
+			keyName = "clanJoinLeave",
+			name = "Join/leave broadcasts",
+			description = "Play a sound for users joining or leaving the clan chat.",
 			position = 21,
 			section = clanChatList
 	)
-	default boolean clanIgnoreJoinLeave()
+	default boolean clanJoinLeave()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "clanNewMember",
+			name = "Clan invitation broadcasts",
+			description = "Play a sound for new players joining the clan.",
+			position = 22,
+			section = clanChatList
+	)
+	default boolean clanNewMember()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanExpelledMember",
+			name = "Clan expulsion broadcasts",
+			description = "Play a sound for clan members being expelled from the clan.",
+			position = 23,
+			section = clanChatList
+	)
+	default boolean clanExpelledMember()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanRegularDrop",
+			name = "Regular drop broadcasts",
+			description = "Play a sound for users receiving a regular drop.",
+			position = 24,
+			section = clanChatList
+	)
+	default boolean clanRegularDrop()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanRareDrop",
+			name = "Rare drop broadcasts",
+			description = "Play a sound for users receiving a rare drop.",
+			position = 25,
+			section = clanChatList
+	)
+	default boolean clanRareDrop()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanRaidLoot",
+			name = "Raid loot broadcasts",
+			description = "Play a sound for users receiving raid loot.",
+			position = 26,
+			section = clanChatList
+	)
+	default boolean clanRaidLoot()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanPetDrop",
+			name = "Pet drop broadcasts",
+			description = "Play a sound for users receiving a pet drop.",
+			position = 27,
+			section = clanChatList
+	)
+	default boolean clanPetDrop()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanCollectionLog",
+			name = "Collection log broadcasts",
+			description = "Play a sound for users receiving a new collection log item.",
+			position = 28,
+			section = clanChatList
+	)
+	default boolean clanCollectionLog()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanLevelUp",
+			name = "Level up broadcasts",
+			description = "Play a sound for users leveling up.",
+			position = 29,
+			section = clanChatList
+	)
+	default boolean clanLevelUp()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanCombatLevel",
+			name = "Combat level broadcasts",
+			description = "Play a sound for users gaining a combat level.",
+			position = 30,
+			section = clanChatList
+	)
+	default boolean clanCombatLevel()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanTotalLevelMilestone",
+			name = "Total level broadcasts",
+			description = "Play a sound for users reaching a new total level milestone.",
+			position = 31,
+			section = clanChatList
+	)
+	default boolean clanTotalLevelMilestone()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanXpMilestone",
+			name = "XP milestone broadcasts",
+			description = "Play a sound for users reaching an XP milestone.",
+			position = 32,
+			section = clanChatList
+	)
+	default boolean clanXpMilestone()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanQuest",
+			name = "Quest broadcasts",
+			description = "Play a sound for clan members completing a quest.",
+			position = 33,
+			section = clanChatList
+	)
+	default boolean clanQuest()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanDiary",
+			name = "Achievement diary broadcasts",
+			description = "Play a sound for clan members completing an achievement diary task.",
+			position = 34,
+			section = clanChatList
+	)
+	default boolean clanDiary()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanCombatAchievement",
+			name = "Combat achievement broadcasts",
+			description = "Play a sound for clan members completing a combat achievement.",
+			position = 35,
+			section = clanChatList
+	)
+	default boolean clanCombatAchievement()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanPersonalBest",
+			name = "Personal best broadcasts",
+			description = "Play a sound for users achieving a new personal best.",
+			position = 36,
+			section = clanChatList
+	)
+	default boolean clanPersonalBest()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanPvpKill",
+			name = "PvP kill broadcasts",
+			description = "Play a sound for clan members killing another player.",
+			position = 37,
+			section = clanChatList
+	)
+	default boolean clanPvpKill()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanPvpDeath",
+			name = "PvP death broadcasts",
+			description = "Play a sound for clan members dying to another player.",
+			position = 38,
+			section = clanChatList
+	)
+	default boolean clanPvpDeath()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanHardcoreDeath",
+			name = "Hardcore death broadcasts",
+			description = "Play a sound for hardcore ironmen dying.",
+			position = 39,
+			section = clanChatList
+	)
+	default boolean clanHardcoreDeath()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanLeagues",
+			name = "Leagues broadcasts",
+			description = "Include leagues broadcasts.",
+			position = 40,
+			section = clanChatList
+	)
+	default boolean clanLeagues()
 	{
 		return true;
 	}
@@ -292,7 +520,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanIgnorePlayers",
 			name = "Ignore player names",
 			description = "A comma-separated list of player names to never play a sound for.",
-			position = 22,
+			position = 41,
 			section = clanChatList
 	)
 	default String clanIgnorePlayersList()
@@ -306,7 +534,7 @@ public interface ChatSoundsConfig extends Config
 	@ConfigSection(
 			name = "Guest Clan Chat",
 			description = "Settings for guest clan chats.",
-			position = 23
+			position = 42
 	)
 	String guestClanList = "guestClanList";
 
@@ -314,7 +542,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "guestClanChat",
 			name = "Guest Clan Chat",
 			description = "The sound effect to use when receiving a guest clan chat message.",
-			position = 24,
+			position = 43,
 			section = guestClanList
 	)
 	default ChatSoundsMode guestClanChat()
@@ -326,7 +554,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "guestClanBroadcast",
 			name = "Guest Clan Broadcast",
 			description = "The sound effect to use when receiving a guest clan broadcast message.",
-			position = 25,
+			position = 44,
 			section = guestClanList
 	)
 	default ChatSoundsMode guestClanBroadcast()
@@ -344,7 +572,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "guestClanChannelVolume",
 			name = "Volume",
 			description = "Sets the volume of the chat message sound effect.",
-			position = 26,
+			position = 45,
 			section = guestClanList
 	)
 	default int guestClanVolume()
@@ -353,13 +581,13 @@ public interface ChatSoundsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "guestClanIgnoreJoinLeave",
-			name = "Ignore joined/left messages",
-			description = "Do not play a sound for users joining or leaving chats.",
-			position = 27,
+			keyName = "guestClanJoinLeave",
+			name = "Join/leave broadcasts",
+			description = "Play a sound for users joining or leaving the guest clan chat.",
+			position = 46,
 			section = guestClanList
 	)
-	default boolean guestClanIgnoreJoinLeave()
+	default boolean guestClanJoinLeave()
 	{
 		return true;
 	}
@@ -368,7 +596,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "guestClanIgnorePlayers",
 			name = "Ignore player names",
 			description = "A comma-separated list of player names to never play a sound for.",
-			position = 28,
+			position = 47,
 			section = guestClanList
 	)
 	default String guestClanIgnorePlayersList()
@@ -382,7 +610,7 @@ public interface ChatSoundsConfig extends Config
 	@ConfigSection(
 			name = "Group Ironman Chat",
 			description = "Settings for group ironman chats.",
-			position = 29
+			position = 48
 	)
 	String groupList = "groupList";
 
@@ -390,7 +618,7 @@ public interface ChatSoundsConfig extends Config
 		keyName = "gimChat",
 		name = "Group Ironman Chat",
 		description = "The sound effect to use when receiving a group ironman chat message.",
-		position = 30,
+		position = 49,
 		section = groupList
 	)
 	default ChatSoundsMode gimChat()
@@ -402,7 +630,7 @@ public interface ChatSoundsConfig extends Config
 		keyName = "gimBroadcast",
 		name = "Group Ironman Broadcast",
 		description = "The sound effect to use when receiving a group ironman broadcast message.",
-		position = 31,
+		position = 50,
 		section = groupList
 	)
 	default ChatSoundsMode gimBroadcast()
@@ -420,7 +648,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "groupIronVolume",
 			name = "Volume",
 			description = "Sets the volume of the chat message sound effect.",
-			position = 32,
+			position = 51,
 			section = groupList
 	)
 	default int groupIronVolume()
@@ -432,7 +660,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "groupIronIgnorePlayers",
 			name = "Ignore player names",
 			description = "A comma-separated list of player names to never play a sound for.",
-			position = 33,
+			position = 52,
 			section = groupList
 	)
 	default String groupIronIgnorePlayersList()
@@ -446,7 +674,7 @@ public interface ChatSoundsConfig extends Config
 	@ConfigSection(
 			name = "Trade Requests",
 			description = "Settings for trade requests.",
-			position = 34
+			position = 53
 	)
 	String tradeList = "tradeList";
 
@@ -454,7 +682,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "tradeRequest",
 			name = "Trade Request",
 			description = "The sound effect to use when receiving a trade request.",
-			position = 35,
+			position = 54,
 			section = tradeList
 	)
 	default ChatSoundsMode tradeRequest()
@@ -472,7 +700,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "tradeVolume",
 			name = "Trade Volume",
 			description = "Sets the volume of the chat message sound effect.",
-			position = 36,
+			position = 55,
 			section = tradeList
 	)
 	default int tradeVolume()
@@ -484,7 +712,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "tradeIgnorePlayers",
 			name = "Ignore player names",
 			description = "A comma-separated list of player names to never play a sound for.",
-			position = 37,
+			position = 56,
 			section = tradeList
 	)
 	default String tradeIgnorePlayersList()
@@ -498,7 +726,7 @@ public interface ChatSoundsConfig extends Config
 	@ConfigSection(
 			name = "Duel Requests",
 			description = "Settings for duel requests.",
-			position = 38
+			position = 57
 	)
 	String duelList = "duelList";
 
@@ -506,7 +734,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "duelRequest",
 			name = "Duel Request",
 			description = "The sound effect to use when receiving a duel request.",
-			position = 39,
+			position = 58,
 			section = duelList
 	)
 	default ChatSoundsMode duelRequest()
@@ -524,7 +752,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "duelVolume",
 			name = "Duel Volume",
 			description = "Sets the volume of the chat message sound effect.",
-			position = 40,
+			position = 59,
 			section = duelList
 	)
 	default int duelVolume()
@@ -536,7 +764,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "duelIgnorePlayers",
 			name = "Ignore player names",
 			description = "A comma-separated list of player names to never play a sound for.",
-			position = 41,
+			position = 60,
 			section = duelList
 	)
 	default String duelIgnorePlayersList()

--- a/src/main/java/com/chatsounds/ChatSoundsConfig.java
+++ b/src/main/java/com/chatsounds/ChatSoundsConfig.java
@@ -201,27 +201,27 @@ public interface ChatSoundsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "chatChannelJoinLeave",
-			name = "Join/leave broadcasts",
-			description = "Play a sound for users joining or leaving the chat-channel.",
-			position = 15,
-			section = chatChannelList
-	)
-	default boolean chatChannelJoinLeave()
-	{
-		return false;
-	}
-
-	@ConfigItem(
 			keyName = "chatChannelIgnorePlayers",
 			name = "Ignore player names",
 			description = "A comma-separated list of player names to never play a sound for.",
-			position = 16,
+			position = 15,
 			section = chatChannelList
 	)
 	default String chatChannelIgnorePlayersList()
 	{
 		return "";
+	}
+
+	@ConfigItem(
+			keyName = "chatChannelJoinLeave",
+			name = "Join/leave broadcasts",
+			description = "Play a sound for users joining or leaving the chat-channel.",
+			position = 16,
+			section = chatChannelList
+	)
+	default boolean chatChannelJoinLeave()
+	{
+		return false;
 	}
 
 	/*************
@@ -277,10 +277,22 @@ public interface ChatSoundsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "clanIgnorePlayers",
+			name = "Ignore player names",
+			description = "A comma-separated list of player names to never play a sound for.",
+			position = 21,
+			section = clanChatList
+	)
+	default String clanIgnorePlayersList()
+	{
+		return "";
+	}
+
+	@ConfigItem(
 			keyName = "clanJoinLeave",
 			name = "Join/leave broadcasts",
 			description = "Play a sound for users joining or leaving the clan chat.",
-			position = 21,
+			position = 22,
 			section = clanChatList
 	)
 	default boolean clanJoinLeave()
@@ -288,12 +300,20 @@ public interface ChatSoundsConfig extends Config
 		return false;
 	}
 
+	@ConfigSection(
+			name = "Clan Chat Toggles",
+			description = "Individual toggles for clan chats.",
+			position = 23,
+			closedByDefault = true
+	)
+	String clanChatToggles = "clanChatToggles";
+
 	@ConfigItem(
 			keyName = "clanNewMember",
 			name = "Clan invitation broadcasts",
 			description = "Play a sound for new players joining the clan.",
-			position = 22,
-			section = clanChatList
+			position = 24,
+			section = clanChatToggles
 	)
 	default boolean clanNewMember()
 	{
@@ -304,8 +324,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanExpelledMember",
 			name = "Clan expulsion broadcasts",
 			description = "Play a sound for clan members being expelled from the clan.",
-			position = 23,
-			section = clanChatList
+			position = 25,
+			section = clanChatToggles
 	)
 	default boolean clanExpelledMember()
 	{
@@ -316,8 +336,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanRegularDrop",
 			name = "Regular drop broadcasts",
 			description = "Play a sound for users receiving a regular drop.",
-			position = 24,
-			section = clanChatList
+			position = 26,
+			section = clanChatToggles
 	)
 	default boolean clanRegularDrop()
 	{
@@ -328,8 +348,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanRareDrop",
 			name = "Rare drop broadcasts",
 			description = "Play a sound for users receiving a rare drop.",
-			position = 25,
-			section = clanChatList
+			position = 27,
+			section = clanChatToggles
 	)
 	default boolean clanRareDrop()
 	{
@@ -340,8 +360,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanRaidLoot",
 			name = "Raid loot broadcasts",
 			description = "Play a sound for users receiving raid loot.",
-			position = 26,
-			section = clanChatList
+			position = 28,
+			section = clanChatToggles
 	)
 	default boolean clanRaidLoot()
 	{
@@ -352,8 +372,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanClueLoot",
 			name = "Clue loot broadcasts",
 			description = "Play a sound for users receiving clue loot.",
-			position = 27,
-			section = clanChatList
+			position = 29,
+			section = clanChatToggles
 	)
 	default boolean clanClueLoot()
 	{
@@ -364,8 +384,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanPetDrop",
 			name = "Pet drop broadcasts",
 			description = "Play a sound for users receiving a pet drop.",
-			position = 27,
-			section = clanChatList
+			position = 30,
+			section = clanChatToggles
 	)
 	default boolean clanPetDrop()
 	{
@@ -376,8 +396,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanCollectionLog",
 			name = "Collection log broadcasts",
 			description = "Play a sound for users receiving a new collection log item.",
-			position = 28,
-			section = clanChatList
+			position = 31,
+			section = clanChatToggles
 	)
 	default boolean clanCollectionLog()
 	{
@@ -388,8 +408,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanLevelUp",
 			name = "Level up broadcasts",
 			description = "Play a sound for users leveling up.",
-			position = 29,
-			section = clanChatList
+			position = 32,
+			section = clanChatToggles
 	)
 	default boolean clanLevelUp()
 	{
@@ -400,8 +420,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanCombatLevel",
 			name = "Combat level broadcasts",
 			description = "Play a sound for users gaining a combat level.",
-			position = 30,
-			section = clanChatList
+			position = 33,
+			section = clanChatToggles
 	)
 	default boolean clanCombatLevel()
 	{
@@ -412,8 +432,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanTotalLevelMilestone",
 			name = "Total level broadcasts",
 			description = "Play a sound for users reaching a new total level milestone.",
-			position = 31,
-			section = clanChatList
+			position = 34,
+			section = clanChatToggles
 	)
 	default boolean clanTotalLevelMilestone()
 	{
@@ -424,8 +444,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanXpMilestone",
 			name = "XP milestone broadcasts",
 			description = "Play a sound for users reaching an XP milestone.",
-			position = 32,
-			section = clanChatList
+			position = 35,
+			section = clanChatToggles
 	)
 	default boolean clanXpMilestone()
 	{
@@ -436,8 +456,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanQuest",
 			name = "Quest broadcasts",
 			description = "Play a sound for clan members completing a quest.",
-			position = 33,
-			section = clanChatList
+			position = 36,
+			section = clanChatToggles
 	)
 	default boolean clanQuest()
 	{
@@ -448,8 +468,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanDiary",
 			name = "Achievement diary broadcasts",
 			description = "Play a sound for clan members completing an achievement diary task.",
-			position = 34,
-			section = clanChatList
+			position = 37,
+			section = clanChatToggles
 	)
 	default boolean clanDiary()
 	{
@@ -460,8 +480,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanCombatAchievementTier",
 			name = "Combat achievement tier broadcasts",
 			description = "Play a sound for clan members completing a combat achievement tier.",
-			position = 35,
-			section = clanChatList
+			position = 38,
+			section = clanChatToggles
 	)
 	default boolean clanCombatAchievementTier()
 	{
@@ -472,8 +492,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanCombatAchievementTask",
 			name = "Combat achievement task broadcasts",
 			description = "Play a sound for clan members completing a combat achievement task.",
-			position = 35,
-			section = clanChatList
+			position = 39,
+			section = clanChatToggles
 	)
 	default boolean clanCombatAchievementTask()
 	{
@@ -484,8 +504,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanPersonalBest",
 			name = "Personal best broadcasts",
 			description = "Play a sound for users achieving a new personal best.",
-			position = 36,
-			section = clanChatList
+			position = 40,
+			section = clanChatToggles
 	)
 	default boolean clanPersonalBest()
 	{
@@ -496,8 +516,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanPvpKill",
 			name = "PvP kill broadcasts",
 			description = "Play a sound for clan members killing another player.",
-			position = 37,
-			section = clanChatList
+			position = 41,
+			section = clanChatToggles
 	)
 	default boolean clanPvpKill()
 	{
@@ -508,8 +528,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanPvpDeath",
 			name = "PvP death broadcasts",
 			description = "Play a sound for clan members dying to another player.",
-			position = 38,
-			section = clanChatList
+			position = 42,
+			section = clanChatToggles
 	)
 	default boolean clanPvpDeath()
 	{
@@ -520,8 +540,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanHardcoreDeath",
 			name = "Hardcore death broadcasts",
 			description = "Play a sound for hardcore ironmen dying.",
-			position = 39,
-			section = clanChatList
+			position = 43,
+			section = clanChatToggles
 	)
 	default boolean clanHardcoreDeath()
 	{
@@ -532,24 +552,12 @@ public interface ChatSoundsConfig extends Config
 			keyName = "clanLeagues",
 			name = "Leagues broadcasts",
 			description = "Include leagues broadcasts.",
-			position = 40,
-			section = clanChatList
+			position = 44,
+			section = clanChatToggles
 	)
 	default boolean clanLeagues()
 	{
 		return true;
-	}
-
-	@ConfigItem(
-			keyName = "clanIgnorePlayers",
-			name = "Ignore player names",
-			description = "A comma-separated list of player names to never play a sound for.",
-			position = 41,
-			section = clanChatList
-	)
-	default String clanIgnorePlayersList()
-	{
-		return "";
 	}
 
 	/**************
@@ -558,7 +566,7 @@ public interface ChatSoundsConfig extends Config
 	@ConfigSection(
 			name = "Guest Clan Chat",
 			description = "Settings for guest clan chats.",
-			position = 42
+			position = 44
 	)
 	String guestClanList = "guestClanList";
 
@@ -566,7 +574,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "guestClanChat",
 			name = "Guest Clan Chat",
 			description = "The sound effect to use when receiving a guest clan chat message.",
-			position = 43,
+			position = 45,
 			section = guestClanList
 	)
 	default ChatSoundsMode guestClanChat()
@@ -578,7 +586,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "guestClanBroadcast",
 			name = "Guest Clan Broadcast",
 			description = "The sound effect to use when receiving a guest clan broadcast message.",
-			position = 44,
+			position = 46,
 			section = guestClanList
 	)
 	default ChatSoundsMode guestClanBroadcast()
@@ -596,7 +604,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "guestClanChannelVolume",
 			name = "Volume",
 			description = "Sets the volume of the chat message sound effect.",
-			position = 45,
+			position = 47,
 			section = guestClanList
 	)
 	default int guestClanVolume()
@@ -608,7 +616,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "guestClanJoinLeave",
 			name = "Join/leave broadcasts",
 			description = "Play a sound for users joining or leaving the guest clan chat.",
-			position = 46,
+			position = 48,
 			section = guestClanList
 	)
 	default boolean guestClanJoinLeave()
@@ -620,7 +628,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "guestClanIgnorePlayers",
 			name = "Ignore player names",
 			description = "A comma-separated list of player names to never play a sound for.",
-			position = 47,
+			position = 49,
 			section = guestClanList
 	)
 	default String guestClanIgnorePlayersList()
@@ -634,7 +642,7 @@ public interface ChatSoundsConfig extends Config
 	@ConfigSection(
 			name = "Group Ironman Chat",
 			description = "Settings for group ironman chats.",
-			position = 48
+			position = 50
 	)
 	String groupList = "groupList";
 
@@ -642,7 +650,7 @@ public interface ChatSoundsConfig extends Config
 		keyName = "gimChat",
 		name = "Group Ironman Chat",
 		description = "The sound effect to use when receiving a group ironman chat message.",
-		position = 49,
+		position = 51,
 		section = groupList
 	)
 	default ChatSoundsMode gimChat()
@@ -654,7 +662,7 @@ public interface ChatSoundsConfig extends Config
 		keyName = "gimBroadcast",
 		name = "Group Ironman Broadcast",
 		description = "The sound effect to use when receiving a group ironman broadcast message.",
-		position = 50,
+		position = 52,
 		section = groupList
 	)
 	default ChatSoundsMode gimBroadcast()
@@ -672,7 +680,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "groupIronVolume",
 			name = "Volume",
 			description = "Sets the volume of the chat message sound effect.",
-			position = 51,
+			position = 53,
 			section = groupList
 	)
 	default int groupIronVolume()
@@ -681,11 +689,31 @@ public interface ChatSoundsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "groupIronIgnorePlayers",
+			name = "Ignore player names",
+			description = "A comma-separated list of player names to never play a sound for.",
+			position = 54,
+			section = groupList
+	)
+	default String groupIronIgnorePlayersList()
+	{
+		return "";
+	}
+
+	@ConfigSection(
+			name = "Group Ironman Toggles",
+			description = "Individual toggles for group ironman.",
+			position = 55,
+			closedByDefault = true
+	)
+	String groupIronmanToggles = "groupIronmanToggles";
+
+	@ConfigItem(
 			keyName = "gimRegularDrop",
 			name = "Regular drop broadcasts",
 			description = "Play a sound for group members receiving a regular drop.",
-			position = 52,
-			section = groupList
+			position = 56,
+			section = groupIronmanToggles
 	)
 	default boolean gimRegularDrop()
 	{
@@ -696,8 +724,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimRareDrop",
 			name = "Rare drop broadcasts",
 			description = "Play a sound for group members receiving a rare drop.",
-			position = 53,
-			section = groupList
+			position = 57,
+			section = groupIronmanToggles
 	)
 	default boolean gimRareDrop()
 	{
@@ -708,8 +736,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimRaidLoot",
 			name = "Raid loot broadcasts",
 			description = "Play a sound for group members receiving raid loot.",
-			position = 54,
-			section = groupList
+			position = 58,
+			section = groupIronmanToggles
 	)
 	default boolean gimRaidLoot()
 	{
@@ -720,8 +748,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimClueLoot",
 			name = "Clue loot broadcasts",
 			description = "Play a sound for group members receiving clue loot.",
-			position = 55,
-			section = groupList
+			position = 59,
+			section = groupIronmanToggles
 	)
 	default boolean gimClueLoot()
 	{
@@ -732,8 +760,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimPetDrop",
 			name = "Pet drop broadcasts",
 			description = "Play a sound for group members receiving a pet drop.",
-			position = 56,
-			section = groupList
+			position = 60,
+			section = groupIronmanToggles
 	)
 	default boolean gimPetDrop()
 	{
@@ -744,8 +772,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimCollectionLog",
 			name = "Collection log broadcasts",
 			description = "Play a sound for group members receiving a new collection log item.",
-			position = 57,
-			section = groupList
+			position = 61,
+			section = groupIronmanToggles
 	)
 	default boolean gimCollectionLog()
 	{
@@ -756,8 +784,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimLevelUp",
 			name = "Level up broadcasts",
 			description = "Play a sound for group members leveling up.",
-			position = 58,
-			section = groupList
+			position = 62,
+			section = groupIronmanToggles
 	)
 	default boolean gimLevelUp()
 	{
@@ -768,8 +796,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimCombatLevel",
 			name = "Combat level broadcasts",
 			description = "Play a sound for group members gaining a combat level.",
-			position = 59,
-			section = groupList
+			position = 63,
+			section = groupIronmanToggles
 	)
 	default boolean gimCombatLevel()
 	{
@@ -780,8 +808,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimTotalLevelMilestone",
 			name = "Total level broadcasts",
 			description = "Play a sound for group members reaching a new total level milestone.",
-			position = 60,
-			section = groupList
+			position = 64,
+			section = groupIronmanToggles
 	)
 	default boolean gimTotalLevelMilestone()
 	{
@@ -792,8 +820,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimXpMilestone",
 			name = "XP milestone broadcasts",
 			description = "Play a sound for group members reaching an XP milestone.",
-			position = 61,
-			section = groupList
+			position = 65,
+			section = groupIronmanToggles
 	)
 	default boolean gimXpMilestone()
 	{
@@ -804,8 +832,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimQuest",
 			name = "Quest broadcasts",
 			description = "Play a sound for group members completing a quest.",
-			position = 62,
-			section = groupList
+			position = 66,
+			section = groupIronmanToggles
 	)
 	default boolean gimQuest()
 	{
@@ -816,8 +844,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimDiary",
 			name = "Achievement diary broadcasts",
 			description = "Play a sound for group members completing an achievement diary task.",
-			position = 63,
-			section = groupList
+			position = 67,
+			section = groupIronmanToggles
 	)
 	default boolean gimDiary()
 	{
@@ -828,8 +856,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimCombatAchievementTier",
 			name = "Combat achievement tier broadcasts",
 			description = "Play a sound for group members completing a combat achievement tier.",
-			position = 64,
-			section = groupList
+			position = 68,
+			section = groupIronmanToggles
 	)
 	default boolean gimCombatAchievementTier()
 	{
@@ -840,8 +868,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimCombatAchievementTask",
 			name = "Combat achievement task broadcasts",
 			description = "Play a sound for group members completing a combat achievement task.",
-			position = 65,
-			section = groupList
+			position = 69,
+			section = groupIronmanToggles
 	)
 	default boolean gimCombatAchievementTask()
 	{
@@ -852,8 +880,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimPersonalBest",
 			name = "Personal best broadcasts",
 			description = "Play a sound for group members achieving a new personal best.",
-			position = 66,
-			section = groupList
+			position = 70,
+			section = groupIronmanToggles
 	)
 	default boolean gimPersonalBest()
 	{
@@ -864,8 +892,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimPvpKill",
 			name = "PvP kill broadcasts",
 			description = "Play a sound for group members killing another player.",
-			position = 67,
-			section = groupList
+			position = 71,
+			section = groupIronmanToggles
 	)
 	default boolean gimPvpKill()
 	{
@@ -876,8 +904,8 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimPvpDeath",
 			name = "PvP death broadcasts",
 			description = "Play a sound for group members dying to another player.",
-			position = 68,
-			section = groupList
+			position = 72,
+			section = groupIronmanToggles
 	)
 	default boolean gimPvpDeath()
 	{
@@ -888,24 +916,12 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimLeagues",
 			name = "Leagues broadcasts",
 			description = "Include leagues broadcasts.",
-			position = 69,
-			section = groupList
+			position = 73,
+			section = groupIronmanToggles
 	)
 	default boolean gimLeagues()
 	{
 		return true;
-	}
-
-	@ConfigItem(
-			keyName = "groupIronIgnorePlayers",
-			name = "Ignore player names",
-			description = "A comma-separated list of player names to never play a sound for.",
-			position = 70,
-			section = groupList
-	)
-	default String groupIronIgnorePlayersList()
-	{
-		return "";
 	}
 
 	/*********
@@ -914,7 +930,7 @@ public interface ChatSoundsConfig extends Config
 	@ConfigSection(
 			name = "Trade Requests",
 			description = "Settings for trade requests.",
-			position = 71
+			position = 74
 	)
 	String tradeList = "tradeList";
 
@@ -922,7 +938,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "tradeRequest",
 			name = "Trade Request",
 			description = "The sound effect to use when receiving a trade request.",
-			position = 72,
+			position = 75,
 			section = tradeList
 	)
 	default ChatSoundsMode tradeRequest()
@@ -940,7 +956,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "tradeVolume",
 			name = "Trade Volume",
 			description = "Sets the volume of the chat message sound effect.",
-			position = 73,
+			position = 76,
 			section = tradeList
 	)
 	default int tradeVolume()
@@ -952,7 +968,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "tradeIgnorePlayers",
 			name = "Ignore player names",
 			description = "A comma-separated list of player names to never play a sound for.",
-			position = 74,
+			position = 77,
 			section = tradeList
 	)
 	default String tradeIgnorePlayersList()
@@ -966,7 +982,7 @@ public interface ChatSoundsConfig extends Config
 	@ConfigSection(
 			name = "Duel Requests",
 			description = "Settings for duel requests.",
-			position = 75
+			position = 78
 	)
 	String duelList = "duelList";
 
@@ -974,7 +990,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "duelRequest",
 			name = "Duel Request",
 			description = "The sound effect to use when receiving a duel request.",
-			position = 76,
+			position = 79,
 			section = duelList
 	)
 	default ChatSoundsMode duelRequest()
@@ -992,7 +1008,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "duelVolume",
 			name = "Duel Volume",
 			description = "Sets the volume of the chat message sound effect.",
-			position = 77,
+			position = 80,
 			section = duelList
 	)
 	default int duelVolume()
@@ -1004,7 +1020,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "duelIgnorePlayers",
 			name = "Ignore player names",
 			description = "A comma-separated list of player names to never play a sound for.",
-			position = 78,
+			position = 81,
 			section = duelList
 	)
 	default String duelIgnorePlayersList()

--- a/src/main/java/com/chatsounds/ChatSoundsConfig.java
+++ b/src/main/java/com/chatsounds/ChatSoundsConfig.java
@@ -445,13 +445,25 @@ public interface ChatSoundsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "clanCombatAchievement",
-			name = "Combat achievement broadcasts",
-			description = "Play a sound for clan members completing a combat achievement.",
+			keyName = "clanCombatAchievementTier",
+			name = "Combat achievement tier broadcasts",
+			description = "Play a sound for clan members completing a combat achievement tier.",
 			position = 35,
 			section = clanChatList
 	)
-	default boolean clanCombatAchievement()
+	default boolean clanCombatAchievementTier()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "clanCombatAchievementTask",
+			name = "Combat achievement task broadcasts",
+			description = "Play a sound for clan members completing a combat achievement task.",
+			position = 35,
+			section = clanChatList
+	)
+	default boolean clanCombatAchievementTask()
 	{
 		return true;
 	}

--- a/src/main/java/com/chatsounds/ChatSoundsConfig.java
+++ b/src/main/java/com/chatsounds/ChatSoundsConfig.java
@@ -566,7 +566,7 @@ public interface ChatSoundsConfig extends Config
 	@ConfigSection(
 			name = "Guest Clan Chat",
 			description = "Settings for guest clan chats.",
-			position = 44
+			position = 45
 	)
 	String guestClanList = "guestClanList";
 
@@ -574,7 +574,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "guestClanChat",
 			name = "Guest Clan Chat",
 			description = "The sound effect to use when receiving a guest clan chat message.",
-			position = 45,
+			position = 46,
 			section = guestClanList
 	)
 	default ChatSoundsMode guestClanChat()
@@ -586,7 +586,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "guestClanBroadcast",
 			name = "Guest Clan Broadcast",
 			description = "The sound effect to use when receiving a guest clan broadcast message.",
-			position = 46,
+			position = 47,
 			section = guestClanList
 	)
 	default ChatSoundsMode guestClanBroadcast()
@@ -604,7 +604,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "guestClanChannelVolume",
 			name = "Volume",
 			description = "Sets the volume of the chat message sound effect.",
-			position = 47,
+			position = 48,
 			section = guestClanList
 	)
 	default int guestClanVolume()
@@ -616,7 +616,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "guestClanJoinLeave",
 			name = "Join/leave broadcasts",
 			description = "Play a sound for users joining or leaving the guest clan chat.",
-			position = 48,
+			position = 49,
 			section = guestClanList
 	)
 	default boolean guestClanJoinLeave()
@@ -628,7 +628,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "guestClanIgnorePlayers",
 			name = "Ignore player names",
 			description = "A comma-separated list of player names to never play a sound for.",
-			position = 49,
+			position = 50,
 			section = guestClanList
 	)
 	default String guestClanIgnorePlayersList()
@@ -642,7 +642,7 @@ public interface ChatSoundsConfig extends Config
 	@ConfigSection(
 			name = "Group Ironman Chat",
 			description = "Settings for group ironman chats.",
-			position = 50
+			position = 51
 	)
 	String groupList = "groupList";
 
@@ -650,7 +650,7 @@ public interface ChatSoundsConfig extends Config
 		keyName = "gimChat",
 		name = "Group Ironman Chat",
 		description = "The sound effect to use when receiving a group ironman chat message.",
-		position = 51,
+		position = 52,
 		section = groupList
 	)
 	default ChatSoundsMode gimChat()
@@ -662,7 +662,7 @@ public interface ChatSoundsConfig extends Config
 		keyName = "gimBroadcast",
 		name = "Group Ironman Broadcast",
 		description = "The sound effect to use when receiving a group ironman broadcast message.",
-		position = 52,
+		position = 53,
 		section = groupList
 	)
 	default ChatSoundsMode gimBroadcast()
@@ -680,7 +680,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "groupIronVolume",
 			name = "Volume",
 			description = "Sets the volume of the chat message sound effect.",
-			position = 53,
+			position = 54,
 			section = groupList
 	)
 	default int groupIronVolume()
@@ -692,7 +692,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "groupIronIgnorePlayers",
 			name = "Ignore player names",
 			description = "A comma-separated list of player names to never play a sound for.",
-			position = 54,
+			position = 55,
 			section = groupList
 	)
 	default String groupIronIgnorePlayersList()
@@ -703,7 +703,7 @@ public interface ChatSoundsConfig extends Config
 	@ConfigSection(
 			name = "Group Ironman Toggles",
 			description = "Individual toggles for group ironman.",
-			position = 55,
+			position = 56,
 			closedByDefault = true
 	)
 	String groupIronmanToggles = "groupIronmanToggles";
@@ -712,7 +712,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimRegularDrop",
 			name = "Regular drop broadcasts",
 			description = "Play a sound for group members receiving a regular drop.",
-			position = 56,
+			position = 57,
 			section = groupIronmanToggles
 	)
 	default boolean gimRegularDrop()
@@ -724,7 +724,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimRareDrop",
 			name = "Rare drop broadcasts",
 			description = "Play a sound for group members receiving a rare drop.",
-			position = 57,
+			position = 58,
 			section = groupIronmanToggles
 	)
 	default boolean gimRareDrop()
@@ -736,7 +736,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimRaidLoot",
 			name = "Raid loot broadcasts",
 			description = "Play a sound for group members receiving raid loot.",
-			position = 58,
+			position = 59,
 			section = groupIronmanToggles
 	)
 	default boolean gimRaidLoot()
@@ -748,7 +748,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimClueLoot",
 			name = "Clue loot broadcasts",
 			description = "Play a sound for group members receiving clue loot.",
-			position = 59,
+			position = 60,
 			section = groupIronmanToggles
 	)
 	default boolean gimClueLoot()
@@ -760,7 +760,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimPetDrop",
 			name = "Pet drop broadcasts",
 			description = "Play a sound for group members receiving a pet drop.",
-			position = 60,
+			position = 61,
 			section = groupIronmanToggles
 	)
 	default boolean gimPetDrop()
@@ -772,7 +772,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimCollectionLog",
 			name = "Collection log broadcasts",
 			description = "Play a sound for group members receiving a new collection log item.",
-			position = 61,
+			position = 62,
 			section = groupIronmanToggles
 	)
 	default boolean gimCollectionLog()
@@ -784,7 +784,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimLevelUp",
 			name = "Level up broadcasts",
 			description = "Play a sound for group members leveling up.",
-			position = 62,
+			position = 63,
 			section = groupIronmanToggles
 	)
 	default boolean gimLevelUp()
@@ -796,7 +796,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimCombatLevel",
 			name = "Combat level broadcasts",
 			description = "Play a sound for group members gaining a combat level.",
-			position = 63,
+			position = 64,
 			section = groupIronmanToggles
 	)
 	default boolean gimCombatLevel()
@@ -808,7 +808,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimTotalLevelMilestone",
 			name = "Total level broadcasts",
 			description = "Play a sound for group members reaching a new total level milestone.",
-			position = 64,
+			position = 65,
 			section = groupIronmanToggles
 	)
 	default boolean gimTotalLevelMilestone()
@@ -820,7 +820,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimXpMilestone",
 			name = "XP milestone broadcasts",
 			description = "Play a sound for group members reaching an XP milestone.",
-			position = 65,
+			position = 66,
 			section = groupIronmanToggles
 	)
 	default boolean gimXpMilestone()
@@ -832,7 +832,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimQuest",
 			name = "Quest broadcasts",
 			description = "Play a sound for group members completing a quest.",
-			position = 66,
+			position = 67,
 			section = groupIronmanToggles
 	)
 	default boolean gimQuest()
@@ -844,7 +844,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimDiary",
 			name = "Achievement diary broadcasts",
 			description = "Play a sound for group members completing an achievement diary task.",
-			position = 67,
+			position = 68,
 			section = groupIronmanToggles
 	)
 	default boolean gimDiary()
@@ -856,7 +856,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimCombatAchievementTier",
 			name = "Combat achievement tier broadcasts",
 			description = "Play a sound for group members completing a combat achievement tier.",
-			position = 68,
+			position = 69,
 			section = groupIronmanToggles
 	)
 	default boolean gimCombatAchievementTier()
@@ -868,7 +868,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimCombatAchievementTask",
 			name = "Combat achievement task broadcasts",
 			description = "Play a sound for group members completing a combat achievement task.",
-			position = 69,
+			position = 70,
 			section = groupIronmanToggles
 	)
 	default boolean gimCombatAchievementTask()
@@ -880,7 +880,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimPersonalBest",
 			name = "Personal best broadcasts",
 			description = "Play a sound for group members achieving a new personal best.",
-			position = 70,
+			position = 71,
 			section = groupIronmanToggles
 	)
 	default boolean gimPersonalBest()
@@ -892,7 +892,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimPvpKill",
 			name = "PvP kill broadcasts",
 			description = "Play a sound for group members killing another player.",
-			position = 71,
+			position = 72,
 			section = groupIronmanToggles
 	)
 	default boolean gimPvpKill()
@@ -904,7 +904,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimPvpDeath",
 			name = "PvP death broadcasts",
 			description = "Play a sound for group members dying to another player.",
-			position = 72,
+			position = 73,
 			section = groupIronmanToggles
 	)
 	default boolean gimPvpDeath()
@@ -916,7 +916,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "gimLeagues",
 			name = "Leagues broadcasts",
 			description = "Include leagues broadcasts.",
-			position = 73,
+			position = 74,
 			section = groupIronmanToggles
 	)
 	default boolean gimLeagues()
@@ -930,7 +930,7 @@ public interface ChatSoundsConfig extends Config
 	@ConfigSection(
 			name = "Trade Requests",
 			description = "Settings for trade requests.",
-			position = 74
+			position = 75
 	)
 	String tradeList = "tradeList";
 
@@ -938,7 +938,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "tradeRequest",
 			name = "Trade Request",
 			description = "The sound effect to use when receiving a trade request.",
-			position = 75,
+			position = 76,
 			section = tradeList
 	)
 	default ChatSoundsMode tradeRequest()
@@ -956,7 +956,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "tradeVolume",
 			name = "Trade Volume",
 			description = "Sets the volume of the chat message sound effect.",
-			position = 76,
+			position = 77,
 			section = tradeList
 	)
 	default int tradeVolume()
@@ -968,7 +968,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "tradeIgnorePlayers",
 			name = "Ignore player names",
 			description = "A comma-separated list of player names to never play a sound for.",
-			position = 77,
+			position = 78,
 			section = tradeList
 	)
 	default String tradeIgnorePlayersList()
@@ -982,7 +982,7 @@ public interface ChatSoundsConfig extends Config
 	@ConfigSection(
 			name = "Duel Requests",
 			description = "Settings for duel requests.",
-			position = 78
+			position = 79
 	)
 	String duelList = "duelList";
 
@@ -990,7 +990,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "duelRequest",
 			name = "Duel Request",
 			description = "The sound effect to use when receiving a duel request.",
-			position = 79,
+			position = 80,
 			section = duelList
 	)
 	default ChatSoundsMode duelRequest()
@@ -1008,7 +1008,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "duelVolume",
 			name = "Duel Volume",
 			description = "Sets the volume of the chat message sound effect.",
-			position = 80,
+			position = 81,
 			section = duelList
 	)
 	default int duelVolume()
@@ -1020,7 +1020,7 @@ public interface ChatSoundsConfig extends Config
 			keyName = "duelIgnorePlayers",
 			name = "Ignore player names",
 			description = "A comma-separated list of player names to never play a sound for.",
-			position = 81,
+			position = 82,
 			section = duelList
 	)
 	default String duelIgnorePlayersList()

--- a/src/main/java/com/chatsounds/ChatSoundsPlugin.java
+++ b/src/main/java/com/chatsounds/ChatSoundsPlugin.java
@@ -8,6 +8,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import javax.sound.sampled.LineUnavailableException;
 import javax.sound.sampled.UnsupportedAudioFileException;
@@ -41,6 +43,11 @@ public class ChatSoundsPlugin extends Plugin
 	private static final String CS_CLAN_GUEST_MSG_3 = "Attempting to reconnect to guest channel automatically...".toLowerCase();
 	private static final String CS_GIM_MSG = "To talk in your Ironman Group's channel, start each line of chat with //// or /g.".toLowerCase();
 	private static final String CS_LEAGUES_MSG = "<img=22>";
+	private static final Pattern PLAYER_PREFIX =
+			Pattern.compile(
+					"^.+?\\s+(has|have|been|achieved|acquired|reached|received|lost|unlocked|completed)\\b",
+					Pattern.CASE_INSENSITIVE
+			);
 
 	private static final File CS_DIR = new File(RuneLite.RUNELITE_DIR.getPath() + File.separator + "chat-sounds");
 	private static final File CS_DEFAULT = new File(CS_DIR, "cs_default.wav");
@@ -117,6 +124,7 @@ public class ChatSoundsPlugin extends Plugin
 		String cleanName = Text.sanitize(chatMessage.getName());
 		ChatMessageType type = chatMessage.getType();
 		String msg = Text.standardize(chatMessage.getMessage());
+		String strippedMsg = stripPlayerName(msg);
 
 		// Turn off sounds for yourself or when not logged in.
 		if (player == null ||
@@ -156,7 +164,7 @@ public class ChatSoundsPlugin extends Plugin
 				break;
 
 			case FRIENDSCHATNOTIFICATION:
-				BroadcastType chatChannelBroadcastType = BroadcastType.detect(msg);
+				BroadcastType chatChannelBroadcastType = BroadcastType.detect(strippedMsg);
 				if (chatChannelBroadcastType == BroadcastType.PLAYER_JOIN_LEAVE) {
 					if (config.chatChannelJoinLeave()) {
 						playSound(config.chatChannelBroadcast(), CS_CHAT_CHANNEL_BROADCAST, config.chatChannelVolume());
@@ -180,7 +188,7 @@ public class ChatSoundsPlugin extends Plugin
 				if (msg.contains(CS_LEAGUES_MSG) && !config.clanLeagues()) {
 					return;
 				}
-				BroadcastType clanBroadcastType = BroadcastType.detect(msg);
+				BroadcastType clanBroadcastType = BroadcastType.detect(strippedMsg);
 				if (shouldAlertClanBroadcastType(clanBroadcastType) && !msg.equals(CS_CLAN_MSG)) {
 					playSound(config.clanBroadcast(), CS_CLAN_BROADCAST, config.clanVolume());
 				}
@@ -195,7 +203,7 @@ public class ChatSoundsPlugin extends Plugin
 
 			case CLAN_GUEST_MESSAGE:
 				// Guest clan only has join/leave broadcasts afaik?
-				BroadcastType guestBroadcastType = BroadcastType.detect(msg);
+				BroadcastType guestBroadcastType = BroadcastType.detect(strippedMsg);
 				if (guestBroadcastType == BroadcastType.PLAYER_JOIN_LEAVE && config.guestClanJoinLeave() &&
 						!msg.equals(CS_CLAN_GUEST_MSG_1) && !msg.startsWith(CS_CLAN_GUEST_MSG_2) && !msg.equals(CS_CLAN_GUEST_MSG_3)) {
 					playSound(config.guestClanBroadcast(), CS_CLAN_GUEST_BROADCAST, config.guestClanVolume());
@@ -239,6 +247,17 @@ public class ChatSoundsPlugin extends Plugin
 			updateLists();
 		}
 	}
+
+	private String stripPlayerName(String message)
+	{
+		Matcher m = PLAYER_PREFIX.matcher(message);
+		if (m.find())
+		{
+			return message.substring(m.start(1));
+		}
+		return message;
+	}
+
 
 	// Returns true if the message is from an ignored player in the chat's type.
 	private boolean shouldIgnorePlayer(List<String> ignoreList, String name) {

--- a/src/main/java/com/chatsounds/ChatSoundsPlugin.java
+++ b/src/main/java/com/chatsounds/ChatSoundsPlugin.java
@@ -40,6 +40,7 @@ public class ChatSoundsPlugin extends Plugin
 	private static final String CS_CLAN_GUEST_MSG_2 = "To talk, start each line of chat with /// or /gc.".toLowerCase();
 	private static final String CS_CLAN_GUEST_MSG_3 = "Attempting to reconnect to guest channel automatically...".toLowerCase();
 	private static final String CS_GIM_MSG = "To talk in your Ironman Group's channel, start each line of chat with //// or /g.".toLowerCase();
+	private static final String CS_LEAGUES_MSG = "<img=22>";
 
 	private static final File CS_DIR = new File(RuneLite.RUNELITE_DIR.getPath() + File.separator + "chat-sounds");
 	private static final File CS_DEFAULT = new File(CS_DIR, "cs_default.wav");
@@ -176,6 +177,9 @@ public class ChatSoundsPlugin extends Plugin
 				break;
 
 			case CLAN_MESSAGE:
+				if (msg.contains(CS_LEAGUES_MSG) && !config.clanLeagues()) {
+					return;
+				}
 				BroadcastType clanBroadcastType = BroadcastType.detect(msg);
 				if (shouldAlertClanBroadcastType(clanBroadcastType) && !msg.equals(CS_CLAN_MSG)) {
 					playSound(config.clanBroadcast(), CS_CLAN_BROADCAST, config.clanVolume());
@@ -283,8 +287,6 @@ public class ChatSoundsPlugin extends Plugin
 				return config.clanPvpDeath();
 			case HARDCORE_DEATH:
 				return config.clanHardcoreDeath();
-			case LEAGUES_BROADCAST:
-				return config.clanLeagues();
 			default:
 				return false;
 		}

--- a/src/main/java/com/chatsounds/ChatSoundsPlugin.java
+++ b/src/main/java/com/chatsounds/ChatSoundsPlugin.java
@@ -296,8 +296,10 @@ public class ChatSoundsPlugin extends Plugin
 				return config.clanQuest();
 			case ACHIEVEMENT_DIARY:
 				return config.clanDiary();
-			case COMBAT_ACHIEVEMENT:
-				return config.clanCombatAchievement();
+			case COMBAT_ACHIEVEMENT_TIER:
+				return config.clanCombatAchievementTier();
+			case COMBAT_ACHIEVEMENT_TASK:
+				return config.clanCombatAchievementTask();
 			case PERSONAL_BEST:
 				return config.clanPersonalBest();
 			case PLAYER_KILL:

--- a/src/main/java/com/chatsounds/ChatSoundsPlugin.java
+++ b/src/main/java/com/chatsounds/ChatSoundsPlugin.java
@@ -48,7 +48,7 @@ public class ChatSoundsPlugin extends Plugin
 	private static final File CS_PUBLIC = new File(CS_DIR, "cs_public.wav");
 	private static final File CS_PRIVATE = new File(CS_DIR, "cs_private.wav");
 	private static final File CS_CHAT_CHANNEL = new File(CS_DIR,"cs_chat_channel.wav");
-	private static final File CS_CHAT_CHANNEL_BROADCAST = new File(CS_DIR, "cs_chat_channel_broadcast.wave");
+	private static final File CS_CHAT_CHANNEL_BROADCAST = new File(CS_DIR, "cs_chat_channel_broadcast.wav");
 	private static final File CS_CLAN = new File(CS_DIR, "cs_clan.wav");
 	private static final File CS_CLAN_BROADCAST = new File(CS_DIR, "cs_clan_broadcast.wav");
 	private static final File CS_CLAN_GUEST = new File(CS_DIR, "cs_clan_guest.wav");

--- a/src/main/java/com/chatsounds/ChatSoundsPlugin.java
+++ b/src/main/java/com/chatsounds/ChatSoundsPlugin.java
@@ -191,6 +191,8 @@ public class ChatSoundsPlugin extends Plugin
 					return;
 				}
 				BroadcastType clanBroadcastType = BroadcastType.detect(strippedMsg);
+				log.debug("Chat Sounds: strippedMsg: " + strippedMsg);
+				log.debug("Chat Sounds: clanBroadcastType: " + clanBroadcastType);
 				if (shouldAlertClanBroadcastType(clanBroadcastType) && !msg.equals(CS_CLAN_MSG)) {
 					playSound(config.clanBroadcast(), CS_CLAN_BROADCAST, config.clanVolume());
 				}
@@ -289,6 +291,8 @@ public class ChatSoundsPlugin extends Plugin
 				return config.clanRaidLoot();
 			case REGULAR_DROP:
 				return config.clanRegularDrop();
+			case CLUE_LOOT:
+				return config.clanClueLoot();
 			case PET:
 				return config.clanPetDrop();
 			case COLLECTION_LOG:

--- a/src/main/java/com/chatsounds/ChatSoundsPlugin.java
+++ b/src/main/java/com/chatsounds/ChatSoundsPlugin.java
@@ -220,7 +220,11 @@ public class ChatSoundsPlugin extends Plugin
 				break;
 
 			case CLAN_GIM_MESSAGE:
-				if (!msg.equals(CS_GIM_MSG)) {
+				if (msg.contains(CS_LEAGUES_MSG) && !config.gimLeagues()) {
+					return;
+				}
+				BroadcastType gimBroadcastType = BroadcastType.detect(strippedMsg);
+				if (shouldAlertGimBroadcastType(gimBroadcastType) && !msg.equals(CS_GIM_MSG)) {
 					playSound(config.gimBroadcast(), CS_GIM_BROADCAST, config.groupIronVolume());
 				}
 				break;
@@ -312,6 +316,49 @@ public class ChatSoundsPlugin extends Plugin
 				return config.clanPvpDeath();
 			case HARDCORE_DEATH:
 				return config.clanHardcoreDeath();
+			default:
+				return false;
+		}
+	}
+
+	private boolean shouldAlertGimBroadcastType(BroadcastType type)
+	{
+		switch (type)
+		{
+			case RARE_DROP:
+				return config.gimRareDrop();
+			case RAID_LOOT:
+				return config.gimRaidLoot();
+			case REGULAR_DROP:
+				return config.gimRegularDrop();
+			case CLUE_LOOT:
+				return config.gimClueLoot();
+			case PET:
+				return config.gimPetDrop();
+			case COLLECTION_LOG:
+				return config.gimCollectionLog();
+			case LEVEL_UP:
+				return config.gimLevelUp();
+			case COMBAT_LEVEL_UP:
+				return config.gimCombatLevel();
+			case TOTAL_LEVEL_MILESTONE:
+				return config.gimTotalLevelMilestone();
+			case XP_MILESTONE:
+				return config.gimXpMilestone();
+			case QUEST_COMPLETE:
+				return config.gimQuest();
+			case ACHIEVEMENT_DIARY:
+				return config.gimDiary();
+			case COMBAT_ACHIEVEMENT_TIER:
+				return config.gimCombatAchievementTier();
+			case COMBAT_ACHIEVEMENT_TASK:
+				return config.gimCombatAchievementTask();
+			case PERSONAL_BEST:
+				return config.gimPersonalBest();
+			case PLAYER_KILL:
+				return config.gimPvpKill();
+			case PLAYER_DEATH:
+				return config.gimPvpDeath();
 			default:
 				return false;
 		}

--- a/src/main/java/com/chatsounds/ChatSoundsPlugin.java
+++ b/src/main/java/com/chatsounds/ChatSoundsPlugin.java
@@ -157,7 +157,7 @@ public class ChatSoundsPlugin extends Plugin
 				break;
 
 			case FRIENDSCHATNOTIFICATION:
-				if (shouldAlertOnJoinOrLeft(msg, config.chatChannelIgnoreJoinLeave()) &&
+				if (shouldAlertBroadcastMessage(msg, config.chatChannelIgnoreJoinLeave()) &&
 						!msg.equals(CS_CHAT_CHANNEL_MSG_1) && !msg.startsWith(CS_CHAT_CHANNEL_MSG_2) &&
 						!msg.equals(CS_CHAT_CHANNEL_MSG_3)) {
 					playSound(config.chatChannelBroadcast(), CS_CHAT_CHANNEL_BROADCAST, config.chatChannelVolume());
@@ -172,7 +172,7 @@ public class ChatSoundsPlugin extends Plugin
 				break;
 
 			case CLAN_MESSAGE:
-				if (shouldAlertOnJoinOrLeft(msg, config.clanIgnoreJoinLeave()) && !msg.equals(CS_CLAN_MSG)) {
+				if (shouldAlertBroadcastMessage(msg, config.clanIgnoreJoinLeave()) && !msg.equals(CS_CLAN_MSG)) {
 					playSound(config.clanBroadcast(), CS_CLAN_BROADCAST, config.clanVolume());
 				}
 				break;
@@ -185,7 +185,7 @@ public class ChatSoundsPlugin extends Plugin
 				break;
 
 			case CLAN_GUEST_MESSAGE:
-				if (shouldAlertOnJoinOrLeft(msg, config.guestClanIgnoreJoinLeave()) &&
+				if (shouldAlertBroadcastMessage(msg, config.guestClanIgnoreJoinLeave()) &&
 						!msg.startsWith(CS_CLAN_GUEST_MSG_1) && !msg.endsWith(CS_CLAN_GUEST_MSG_2) &&
 						!msg.equals(CS_CLAN_GUEST_MSG_3)) {
 					playSound(config.guestClanBroadcast(), CS_CLAN_GUEST_BROADCAST, config.guestClanVolume());
@@ -235,14 +235,12 @@ public class ChatSoundsPlugin extends Plugin
 		return ignoreList.stream().anyMatch(s -> s.equalsIgnoreCase(name));
     }
 
-	// Returns false if it is not a "join" or "left" message. If it is one, returns true if ignore is
-	// not checked, false if it is checked.
-	private boolean shouldAlertOnJoinOrLeft(String text, boolean ignore) {
-		if (!text.endsWith(HAS_JOINED) && !text.endsWith(HAS_LEFT)) {
-			return false;
+	private boolean shouldAlertBroadcastMessage(String text, boolean ignoreJoinLeave) {
+		boolean isJoinOrLeft = text.endsWith(HAS_JOINED) || text.endsWith(HAS_LEFT);
+		if (isJoinOrLeft) {
+			return !ignoreJoinLeave; // Return false on ignored join/leave messages.
 		}
-
-        return !ignore;
+		return true; // Return true for other broadcast messages.
     }
 
 	private void initSoundFiles()

--- a/src/main/java/com/chatsounds/ChatSoundsPlugin.java
+++ b/src/main/java/com/chatsounds/ChatSoundsPlugin.java
@@ -120,23 +120,27 @@ public class ChatSoundsPlugin extends Plugin
 	public void onChatMessage(ChatMessage chatMessage)
 	{
 		Player player = client.getLocalPlayer();
-		String playerName = player.getName() != null ? player.getName() : "";
+		String playerName = player != null && player.getName() != null ? player.getName() : "";
+		String cleanPlayerName = Text.sanitize(playerName);
 		String cleanName = Text.sanitize(chatMessage.getName());
 		ChatMessageType type = chatMessage.getType();
 
 		String msg = Text.standardize(chatMessage.getMessage());
 		String cleanMsg = Text.removeTags(msg);
+		String cleanBroadcastName = Text.sanitize(extractBroadcastPlayerName(cleanMsg));
 		String strippedMsg = stripPlayerName(cleanMsg);
 
 		// Turn off sounds for yourself or when not logged in.
 		if (player == null ||
 				client.getGameState() != GameState.LOGGED_IN ||
-				cleanName.equalsIgnoreCase(Text.sanitize(playerName))) {
+				cleanName.equalsIgnoreCase(cleanPlayerName) ||
+				cleanBroadcastName.equalsIgnoreCase(cleanPlayerName)) {
 			return;
 		}
 
 		// Turn off sounds for global settings.
-		if (shouldIgnorePlayer(allIgnored, cleanName) || config.allChats() == GlobalSoundsMode.ON) {
+		if (shouldIgnorePlayer(allIgnored, cleanName) || shouldIgnorePlayer(allIgnored, cleanBroadcastName) ||
+				config.allChats() == GlobalSoundsMode.ON) {
 			return;
 		}
 
@@ -167,6 +171,9 @@ public class ChatSoundsPlugin extends Plugin
 
 			case FRIENDSCHATNOTIFICATION:
 				BroadcastType chatChannelBroadcastType = BroadcastType.detect(strippedMsg);
+				if (shouldIgnorePlayer(chatChannelIgnored, cleanBroadcastName)) {
+					return;
+				}
 				if (chatChannelBroadcastType == BroadcastType.PLAYER_JOIN_LEAVE) {
 					if (config.chatChannelJoinLeave()) {
 						playSound(config.chatChannelBroadcast(), CS_CHAT_CHANNEL_BROADCAST, config.chatChannelVolume());
@@ -191,6 +198,9 @@ public class ChatSoundsPlugin extends Plugin
 					return;
 				}
 				BroadcastType clanBroadcastType = BroadcastType.detect(strippedMsg);
+				if (shouldIgnorePlayer(clanIgnored, cleanBroadcastName)) {
+					return;
+				}
 				if (shouldAlertClanBroadcastType(clanBroadcastType) && !msg.equals(CS_CLAN_MSG)) {
 					playSound(config.clanBroadcast(), CS_CLAN_BROADCAST, config.clanVolume());
 				}
@@ -206,6 +216,9 @@ public class ChatSoundsPlugin extends Plugin
 			case CLAN_GUEST_MESSAGE:
 				// Guest clan only has join/leave broadcasts afaik?
 				BroadcastType guestBroadcastType = BroadcastType.detect(strippedMsg);
+				if (shouldIgnorePlayer(guestClanIgnored, cleanBroadcastName)) {
+					return;
+				}
 				if (guestBroadcastType == BroadcastType.PLAYER_JOIN_LEAVE && config.guestClanJoinLeave() &&
 						!msg.equals(CS_CLAN_GUEST_MSG_1) && !msg.startsWith(CS_CLAN_GUEST_MSG_2) && !msg.equals(CS_CLAN_GUEST_MSG_3)) {
 					playSound(config.guestClanBroadcast(), CS_CLAN_GUEST_BROADCAST, config.guestClanVolume());
@@ -224,6 +237,9 @@ public class ChatSoundsPlugin extends Plugin
 					return;
 				}
 				BroadcastType gimBroadcastType = BroadcastType.detect(strippedMsg);
+				if (shouldIgnorePlayer(gimIgnored, cleanBroadcastName)) {
+					return;
+				}
 				if (shouldAlertGimBroadcastType(gimBroadcastType) && !msg.equals(CS_GIM_MSG)) {
 					playSound(config.gimBroadcast(), CS_GIM_BROADCAST, config.groupIronVolume());
 				}
@@ -264,6 +280,15 @@ public class ChatSoundsPlugin extends Plugin
 		return message;
 	}
 
+	private String extractBroadcastPlayerName(String message)
+	{
+		Matcher m = PLAYER_PREFIX.matcher(message);
+		if (m.find())
+		{
+			return message.substring(0, m.start(1)).trim();
+		}
+		return "";
+	}
 
 	// Returns true if the message is from an ignored player in the chat's type.
 	private boolean shouldIgnorePlayer(List<String> ignoreList, String name) {

--- a/src/main/java/com/chatsounds/ChatSoundsPlugin.java
+++ b/src/main/java/com/chatsounds/ChatSoundsPlugin.java
@@ -32,8 +32,6 @@ import net.runelite.client.util.Text;
 )
 public class ChatSoundsPlugin extends Plugin
 {
-	private static final String HAS_JOINED = " has joined.".toLowerCase();;
-	private static final String HAS_LEFT = " has left.".toLowerCase();;
 	private static final String CS_CHAT_CHANNEL_MSG_1 = "Attempting to join chat-channel...".toLowerCase();
 	private static final String CS_CHAT_CHANNEL_MSG_2 = "Now talking in chat-channel ".toLowerCase();
 	private static final String CS_CHAT_CHANNEL_MSG_3 = "To talk, start each line of chat with the / symbol.".toLowerCase();
@@ -157,8 +155,14 @@ public class ChatSoundsPlugin extends Plugin
 				break;
 
 			case FRIENDSCHATNOTIFICATION:
-				if (shouldAlertBroadcastMessage(msg, config.chatChannelIgnoreJoinLeave()) &&
-						!msg.equals(CS_CHAT_CHANNEL_MSG_1) && !msg.startsWith(CS_CHAT_CHANNEL_MSG_2) &&
+				BroadcastType chatChannelBroadcastType = BroadcastType.detect(msg);
+				if (chatChannelBroadcastType == BroadcastType.PLAYER_JOIN_LEAVE) {
+					if (config.chatChannelJoinLeave()) {
+						playSound(config.chatChannelBroadcast(), CS_CHAT_CHANNEL_BROADCAST, config.chatChannelVolume());
+					}
+					return;
+				}
+				else if (!msg.equals(CS_CHAT_CHANNEL_MSG_1) && !msg.startsWith(CS_CHAT_CHANNEL_MSG_2) &&
 						!msg.equals(CS_CHAT_CHANNEL_MSG_3)) {
 					playSound(config.chatChannelBroadcast(), CS_CHAT_CHANNEL_BROADCAST, config.chatChannelVolume());
 				}
@@ -172,7 +176,8 @@ public class ChatSoundsPlugin extends Plugin
 				break;
 
 			case CLAN_MESSAGE:
-				if (shouldAlertBroadcastMessage(msg, config.clanIgnoreJoinLeave()) && !msg.equals(CS_CLAN_MSG)) {
+				BroadcastType clanBroadcastType = BroadcastType.detect(msg);
+				if (shouldAlertClanBroadcastType(clanBroadcastType) && !msg.equals(CS_CLAN_MSG)) {
 					playSound(config.clanBroadcast(), CS_CLAN_BROADCAST, config.clanVolume());
 				}
 				break;
@@ -185,9 +190,10 @@ public class ChatSoundsPlugin extends Plugin
 				break;
 
 			case CLAN_GUEST_MESSAGE:
-				if (shouldAlertBroadcastMessage(msg, config.guestClanIgnoreJoinLeave()) &&
-						!msg.startsWith(CS_CLAN_GUEST_MSG_1) && !msg.endsWith(CS_CLAN_GUEST_MSG_2) &&
-						!msg.equals(CS_CLAN_GUEST_MSG_3)) {
+				// Guest clan only has join/leave broadcasts afaik?
+				BroadcastType guestBroadcastType = BroadcastType.detect(msg);
+				if (guestBroadcastType == BroadcastType.PLAYER_JOIN_LEAVE && config.guestClanJoinLeave() &&
+						!msg.equals(CS_CLAN_GUEST_MSG_1) && !msg.startsWith(CS_CLAN_GUEST_MSG_2) && !msg.equals(CS_CLAN_GUEST_MSG_3)) {
 					playSound(config.guestClanBroadcast(), CS_CLAN_GUEST_BROADCAST, config.guestClanVolume());
 				}
 				break;
@@ -235,13 +241,54 @@ public class ChatSoundsPlugin extends Plugin
 		return ignoreList.stream().anyMatch(s -> s.equalsIgnoreCase(name));
     }
 
-	private boolean shouldAlertBroadcastMessage(String text, boolean ignoreJoinLeave) {
-		boolean isJoinOrLeft = text.endsWith(HAS_JOINED) || text.endsWith(HAS_LEFT);
-		if (isJoinOrLeft) {
-			return !ignoreJoinLeave; // Return false on ignored join/leave messages.
+	private boolean shouldAlertClanBroadcastType(BroadcastType type)
+	{
+		switch (type)
+		{
+			case PLAYER_JOIN_LEAVE:
+				return config.clanJoinLeave();
+			case CLAN_INVITATION:
+				return config.clanNewMember();
+			case CLAN_EXPULSION:
+				return config.clanExpelledMember();
+			case RARE_DROP:
+				return config.clanRareDrop();
+			case RAID_LOOT:
+				return config.clanRaidLoot();
+			case REGULAR_DROP:
+				return config.clanRegularDrop();
+			case PET:
+				return config.clanPetDrop();
+			case COLLECTION_LOG:
+				return config.clanCollectionLog();
+			case LEVEL_UP:
+				return config.clanLevelUp();
+			case COMBAT_LEVEL_UP:
+				return config.clanCombatLevel();
+			case TOTAL_LEVEL_MILESTONE:
+				return config.clanTotalLevelMilestone();
+			case XP_MILESTONE:
+				return config.clanXpMilestone();
+			case QUEST_COMPLETE:
+				return config.clanQuest();
+			case ACHIEVEMENT_DIARY:
+				return config.clanDiary();
+			case COMBAT_ACHIEVEMENT:
+				return config.clanCombatAchievement();
+			case PERSONAL_BEST:
+				return config.clanPersonalBest();
+			case PLAYER_KILL:
+				return config.clanPvpKill();
+			case PLAYER_DEATH:
+				return config.clanPvpDeath();
+			case HARDCORE_DEATH:
+				return config.clanHardcoreDeath();
+			case LEAGUES_BROADCAST:
+				return config.clanLeagues();
+			default:
+				return false;
 		}
-		return true; // Return true for other broadcast messages.
-    }
+	}
 
 	private void initSoundFiles()
 	{

--- a/src/main/java/com/chatsounds/ChatSoundsPlugin.java
+++ b/src/main/java/com/chatsounds/ChatSoundsPlugin.java
@@ -45,7 +45,7 @@ public class ChatSoundsPlugin extends Plugin
 	private static final String CS_LEAGUES_MSG = "<img=22>";
 	private static final Pattern PLAYER_PREFIX =
 			Pattern.compile(
-					"^.+\\s+(has|have|been|achieved|acquired|reached|received|lost|unlocked|completed)\\b",
+					"^.+?\\s+(has|have|been|achieved|acquired|reached|received|lost|unlocked|completed)\\b",
 					Pattern.CASE_INSENSITIVE
 			);
 

--- a/src/main/java/com/chatsounds/ChatSoundsPlugin.java
+++ b/src/main/java/com/chatsounds/ChatSoundsPlugin.java
@@ -125,7 +125,7 @@ public class ChatSoundsPlugin extends Plugin
 		ChatMessageType type = chatMessage.getType();
 
 		String msg = Text.standardize(chatMessage.getMessage());
-		String cleanMsg = stripTags(msg);
+		String cleanMsg = Text.removeTags(msg);
 		String strippedMsg = stripPlayerName(cleanMsg);
 
 		// Turn off sounds for yourself or when not logged in.
@@ -249,13 +249,6 @@ public class ChatSoundsPlugin extends Plugin
 			updateLists();
 		}
 	}
-
-	private String stripTags(String message)
-	{
-		// Remove any <...> tags
-		return message.replaceAll("<[^>]*>", "");
-	}
-
 
 	private String stripPlayerName(String message)
 	{

--- a/src/main/java/com/chatsounds/ChatSoundsPlugin.java
+++ b/src/main/java/com/chatsounds/ChatSoundsPlugin.java
@@ -191,8 +191,6 @@ public class ChatSoundsPlugin extends Plugin
 					return;
 				}
 				BroadcastType clanBroadcastType = BroadcastType.detect(strippedMsg);
-				log.debug("Chat Sounds: strippedMsg: " + strippedMsg);
-				log.debug("Chat Sounds: clanBroadcastType: " + clanBroadcastType);
 				if (shouldAlertClanBroadcastType(clanBroadcastType) && !msg.equals(CS_CLAN_MSG)) {
 					playSound(config.clanBroadcast(), CS_CLAN_BROADCAST, config.clanVolume());
 				}

--- a/src/main/java/com/chatsounds/ChatSoundsPlugin.java
+++ b/src/main/java/com/chatsounds/ChatSoundsPlugin.java
@@ -45,7 +45,7 @@ public class ChatSoundsPlugin extends Plugin
 	private static final String CS_LEAGUES_MSG = "<img=22>";
 	private static final Pattern PLAYER_PREFIX =
 			Pattern.compile(
-					"^.+?\\s+(has|have|been|achieved|acquired|reached|received|lost|unlocked|completed)\\b",
+					"^.+\\s+(has|have|been|achieved|acquired|reached|received|lost|unlocked|completed)\\b",
 					Pattern.CASE_INSENSITIVE
 			);
 
@@ -123,8 +123,10 @@ public class ChatSoundsPlugin extends Plugin
 		String playerName = player.getName() != null ? player.getName() : "";
 		String cleanName = Text.sanitize(chatMessage.getName());
 		ChatMessageType type = chatMessage.getType();
+
 		String msg = Text.standardize(chatMessage.getMessage());
-		String strippedMsg = stripPlayerName(msg);
+		String cleanMsg = stripTags(msg);
+		String strippedMsg = stripPlayerName(cleanMsg);
 
 		// Turn off sounds for yourself or when not logged in.
 		if (player == null ||
@@ -247,6 +249,13 @@ public class ChatSoundsPlugin extends Plugin
 			updateLists();
 		}
 	}
+
+	private String stripTags(String message)
+	{
+		// Remove any <...> tags
+		return message.replaceAll("<[^>]*>", "");
+	}
+
 
 	private String stripPlayerName(String message)
 	{

--- a/src/main/java/com/chatsounds/MatchMode.java
+++ b/src/main/java/com/chatsounds/MatchMode.java
@@ -3,5 +3,6 @@ package com.chatsounds;
 public enum MatchMode
 {
     ANY,   // any string may match
-    ALL    // all strings must match
+    ALL,   // all strings must match
+    REGEX  // match using regular expression
 }

--- a/src/main/java/com/chatsounds/MatchMode.java
+++ b/src/main/java/com/chatsounds/MatchMode.java
@@ -1,0 +1,7 @@
+package com.chatsounds;
+
+public enum MatchMode
+{
+    ANY,   // any string may match
+    ALL    // all strings must match
+}


### PR DESCRIPTION
This PR fixes an issue where broadcast alerts were being suppressed by join/leave message filtering logic.
Also updates the readme to reflect wav-only audio support as of 410f959e7e35773455db52878d3a6b7fa4311418.